### PR TITLE
Use new QSSTV homepage url

### DIFF
--- a/be.telenet.user.QSSTV.metainfo.xml
+++ b/be.telenet.user.QSSTV.metainfo.xml
@@ -13,11 +13,11 @@
  </description>
  <screenshots>
   <screenshot type="default">
-   <image>https://community.linuxmint.com/img/screenshots/qsstv.png</image>
-   <caption>Receive HAMDRM Window</caption>
+   <image>https://www.qsl.net/on4qz/qsstv/manual/rxwidget1.png</image>
+   <caption>Receive SSTV Window</caption>
   </screenshot>
  </screenshots>
- <url type="homepage">http://users.telenet.be/on4qz</url>
+ <url type="homepage">https://www.qsl.net/on4qz/</url>
  <releases>
   <release version="9.5.8" date="2021-08-03"/>
   <release version="9.4.4" date="2019-08-04"/>

--- a/be.telenet.user.QSSTV.yml
+++ b/be.telenet.user.QSSTV.yml
@@ -34,8 +34,8 @@ modules:
       - QMAKE_LIBDIR=/app/lib
     sources:
       - type: archive
-        url: http://deb.debian.org/debian/pool/main/q/qsstv/qsstv_9.5.8.orig.tar.xz
-        sha256: 125d5032fd470ddfa2b76b2c8b3da6ca25eeddf02282f1f6378379c7a8d777e5
+        url: https://www.qsl.net/o/on4qz//qsstv/downloads/qsstv_9.5.8.tar.gz
+        sha256: c03f7fa5c680ced8fd331c25ff3e47440c9aedb48ec7b66255c6aa0ed88e7a68
       - type: file
         path: be.telenet.user.QSSTV.metainfo.xml
     post-install:


### PR DESCRIPTION
QSSTV homepage was migrated to qsl.net. The old homepage url does not work anymore.